### PR TITLE
Change interpreter path

### DIFF
--- a/nodes/ecosystem.config.js
+++ b/nodes/ecosystem.config.js
@@ -4,7 +4,7 @@ module.exports = {
         name   : "validator",
         script : "/opt/server/chompchain-node/nodes/validator/main.py",
         exec_mode: "fork",
-        interpreter: "/usr/bin/python"
+        interpreter: "python"
     },
     {
         name   : "registry",


### PR DESCRIPTION
Updating the container to 3.11 for `pymerkle` changed the binary path for the appropriate Python install.